### PR TITLE
Check data attributes for type (make index 0 work)

### DIFF
--- a/src/jquery.ascensor.js
+++ b/src/jquery.ascensor.js
@@ -191,13 +191,13 @@
 
       this.node.on('next', function(event, floor) {
         var dataAttributeDirection = self.nodeChildren.eq(self.floorActive).data(self.dataAttributeMap.next);
-        if (dataAttributeDirection) return self.scrollToFloor(dataAttributeDirection);
+        if (isNumber(dataAttributeDirection) || isString(dataAttributeDirection)) return self.scrollToFloor(dataAttributeDirection);
         self.next();
       });
 
       this.node.on('prev', function(event, floor) {
         var dataAttributeDirection = self.nodeChildren.eq(self.floorActive).data(self.dataAttributeMap.prev);
-        if (dataAttributeDirection) return self.scrollToFloor(dataAttributeDirection);
+        if (isNumber(dataAttributeDirection) || isString(dataAttributeDirection)) return self.scrollToFloor(dataAttributeDirection);
         self.prev();
       });
 
@@ -682,7 +682,7 @@
       // If a data attribute with current direction
       // is found, use it.
       var dataAttributeDirection = this.nodeChildren.eq(this.floorActive).data(this.dataAttributeMap[direction]);
-      if (dataAttributeDirection) return self.scrollToFloor(dataAttributeDirection);
+      if (isNumber(dataAttributeDirection) || isString(dataAttributeDirection)) return self.scrollToFloor(dataAttributeDirection);
 
 
       var directionIsHorizontal = (direction == 'right' || direction == 'left');


### PR DESCRIPTION
Hi there!

When using the plugin we discovered a bug where the data attribute wasn't recognized. This was due to the fact that there is an if statement that basically let's Javascript "decide" if the given data is okay or not.

We wanted to scroll to the floor using the index 0 which did not work.
JS is interpreting 0 as false and the data attribute is not used.

I created a patch that checks for the data type to ensure that something like using the number 0 works.

**Important**
I could not run the tests on my machine. I got a lot of errors regarding Jasmine.  
That's the reason I also did not include any other file generated by Grunt.

Thanks for the great plugin :)