### PR TITLE
npm install issue resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Ascensor is a jquery plugin which aims to train and adapt content according to an elevator system ([homepage](http://kirkas.ch/ascensor))
 
-
-
 <!-- Section - Getting started -->
 ### Getting Started
 Download the [production version][min] or the [development version][max].
@@ -77,9 +75,9 @@ ascensor.on("scrollEnd", function(e, floor){
 
 <!-- Section - Data attribute -->
 ### NEW! - Data attribute
-Sometime you need a floor to behave differently in term of direction, you can now easily force this by adding a custom data-attribute on the dom element.
+Sometime you need a floor to behave differently in term of direction, you can force this by adding a custom data-attribute to the DOM element.
 
-Here the available attribute:
+Available attributes:
 
 `data-ascensor-next`<br/>
 `data-ascensor-prev`<br/>
@@ -240,10 +238,9 @@ Note that all example are situated in the examples folder of the repository <br/
 
 
 <!-- Section - Contribution  -->
-####Contribution
+###Contribution
 
-You want help? great!
-For my workflow, I use [grunt.js](http://gruntjs.com/) (require node & npm installed)
+You want to help? great!
 
 1. Fork it
 2. Create your feature branch (git checkout -b my-new-feature)
@@ -253,8 +250,17 @@ For my workflow, I use [grunt.js](http://gruntjs.com/) (require node & npm insta
 6. Push to the branch (git push origin my-new-feature) & request pull request!
 
 
-<!-- Section - Donation  -->
-####Donation
 
-####Author
+<!-- Section - Developer Build -->
+### Development Build
+
+This project uses [npm](https://www.npmjs.com/) and [grunt.js](http://gruntjs.com/).
+
+1. npm install
+2. grunt
+
+<!-- Section - Donation  -->
+###Donation
+
+###Author
 Léo Galley

--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ For my workflow, I use [grunt.js](http://gruntjs.com/) (require node & npm insta
 
 <!-- Section - Donation  -->
 ####Donation
-https://cash.me/$kirkas
 
 ####Author
 Léo Galley

--- a/package.json
+++ b/package.json
@@ -6,10 +6,6 @@
   "main": "jquery.ascensor.js",
   "license": "BSD",
   "repository": "https://github.com/kirkas/Ascensor.js",
-  "engines": {
-    "node": ">= 0.8.0",
-    "npm": "1.2.15"
-  },
   "devDependencies": {
     "grunt-contrib-jshint": "0.11.1",
     "grunt-contrib-concat": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Léo Galley <contact@kirkas.ch>",
   "description": "Ascensor is a jquery plugin which aims to train and adapt content according to an elevator system",
   "main": "jquery.ascensor.js",
-  "license": "BSD",
+  "license": "MIT",
   "repository": "https://github.com/kirkas/Ascensor.js",
   "devDependencies": {
     "grunt-contrib-jshint": "0.11.1",


### PR DESCRIPTION
I had an issue with running `npm install` due to explicitly set versions in `package.json`.

``` bash
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:100:13)
gyp ERR! stack     at ChildProcess.emit (events.js:185:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Darwin 15.5.0
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/davidcondrey/Github/Ascensor.js/node_modules/libxmljs
gyp ERR! node -v v5.8.0
gyp ERR! node-gyp -v v3.2.1
gyp ERR! not ok
```

Removed unnecessary setting from `package.json` resolved the issue.  Since I was at it, I also resolved license warning and some minor copyedits.  The donate link was 404 and some of the examples were dead, or no longer implementing script.
