### PR TITLE
Solve #78 issue, correct order axis movement defined en queued option

### DIFF
--- a/dist/jquery.ascensor.js
+++ b/dist/jquery.ascensor.js
@@ -668,7 +668,7 @@ author: Léo Galley <contact@kirkas.ch>
           // => Set scrollLeft property
           // => Set callback to a second animation (scrollTop)
           // => return animationSettings
-          else {
+          else if (self.options.queued === 'x') {
             animationSettings.property.scrollLeft = scrollLeftValue;
             secondAnimationSettings.property.scrollTop = scrollTopValue;
             animationSettings.callback = function() {
@@ -690,7 +690,7 @@ author: Léo Galley <contact@kirkas.ch>
           // => Set scrollTop property
           // => Set callback to a second animation (scrollLeft)
           // => return animationSettings
-          else {
+          else if (self.options.queued === 'y') {
             animationSettings.property.scrollTop = scrollTopValue;
             secondAnimationSettings.property.scrollLeft = scrollLeftValue;
             animationSettings.callback = function() {

--- a/src/jquery.ascensor.js
+++ b/src/jquery.ascensor.js
@@ -660,7 +660,7 @@
           // => Set scrollLeft property
           // => Set callback to a second animation (scrollTop)
           // => return animationSettings
-          else {
+          else if (self.options.queued === 'x') {
             animationSettings.property.scrollLeft = scrollLeftValue;
             secondAnimationSettings.property.scrollTop = scrollTopValue;
             animationSettings.callback = function() {
@@ -682,7 +682,7 @@
           // => Set scrollTop property
           // => Set callback to a second animation (scrollLeft)
           // => return animationSettings
-          else {
+          else if (self.options.queued === 'y') {
             animationSettings.property.scrollTop = scrollTopValue;
             secondAnimationSettings.property.scrollLeft = scrollLeftValue;
             animationSettings.callback = function() {


### PR DESCRIPTION
Sorry I'm not familiar with using grunt.js. That is why I have not been able to follow your request.

There is a fault when the "queued" option is set, since regardless of whether it is set to "x" or "y", the first movement that is always performed is on the Y axis.

This pull request solves this problem.